### PR TITLE
Feature/feature iops 2205 ods examples

### DIFF
--- a/examples/ODS-Organization-4VE03-Example.xml
+++ b/examples/ODS-Organization-4VE03-Example.xml
@@ -1,0 +1,72 @@
+<Organization xmlns="http://hl7.org/fhir">
+  <id value="ODS-Organization-4VE03-Example" />
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-DateTime">
+    <extension url="type">
+      <valueCoding>
+        <system value="https://fhir.nhs.uk/England/CodeSystem/England-ORDDateTime" />
+        <code value="last-change-date" />
+        <display value="Last Change Date" />
+      </valueCoding>
+    </extension>
+    <extension url="dateTime">
+      <valueDateTime value="2002-03-31" />
+    </extension>
+  </extension>
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
+    <extension url="dateType">
+      <valueCoding>
+        <system value="https://fhir.nhs.uk/England/CodeSystem/England-PeriodType" />
+        <code value="legal" />
+        <display value="Legal" />
+      </valueCoding>
+    </extension>
+    <extension url="period">
+      <valuePeriod>
+        <start value="1999-04-01" />
+        <end value="2002-03-31" />
+      </valuePeriod>
+    </extension>
+  </extension>
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
+    <extension url="dateType">
+      <valueCoding>
+        <system value="https://fhir.nhs.uk/England/CodeSystem/England-PeriodType" />
+        <code value="operational" />
+        <display value="Operational" />
+      </valueCoding>
+    </extension>
+    <extension url="period">
+      <valuePeriod>
+        <start value="1999-04-01" />
+        <end value="2002-03-31" />
+      </valuePeriod>
+    </extension>
+  </extension>
+  <identifier>
+    <use value="official" />
+    <system value="https://fhir.nhs.uk/Id/ods-organization-code" />
+    <value value="4VE03" />
+  </identifier>
+  <active value="false" />
+  <name value="HIGH WEALD PCG" />
+  <address>
+    <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AddressKey">
+      <extension url="type">
+        <valueCoding>
+          <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-AddressKeyType" />
+          <code value="UPRN" />
+          <display value="Unique Property Reference Number" />
+        </valueCoding>
+      </extension>
+      <extension url="value">
+        <valueString value="10091054340" />
+      </extension>
+    </extension>
+    <line value="ROTHER HOUSE" />
+    <line value="THE OFFICE VILLAGE, RIVER WAY" />
+    <city value="UCKFIELD" />
+    <district value="EAST SUSSEX" />
+    <postalCode value="TN22 1SL" />
+    <country value="ENGLAND" />
+  </address>
+</Organization>

--- a/examples/ODS-Organization-Example.xml
+++ b/examples/ODS-Organization-Example.xml
@@ -1,0 +1,56 @@
+<Organization xmlns="http://hl7.org/fhir">
+  <id value="ODS-Organization-Example" />
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-DateTime">
+    <extension url="type">
+      <valueCoding>
+        <system value="https://fhir.nhs.uk/England/CodeSystem/England-ORDDateTime" />
+        <code value="last-change-date" />
+        <display value="Last Change Date" />
+      </valueCoding>
+    </extension>
+    <extension url="dateTime">
+      <valueDateTime value="2020-09-24" />
+    </extension>
+  </extension>
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
+    <extension url="dateType">
+      <valueCoding>
+        <system value="https://fhir.nhs.uk/England/CodeSystem/England-PeriodType" />
+        <code value="legal" />
+        <display value="Legal" />
+      </valueCoding>
+    </extension>
+    <extension url="period">
+      <valuePeriod>
+        <start value="2015-05-11" />
+      </valuePeriod>
+    </extension>
+  </extension>
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
+    <extension url="dateType">
+      <valueCoding>
+        <system value="https://fhir.nhs.uk/England/CodeSystem/England-PeriodType" />
+        <code value="operational" />
+        <display value="Operational" />
+      </valueCoding>
+    </extension>
+    <extension url="period">
+      <valuePeriod>
+        <start value="2015-05-11" />
+      </valuePeriod>
+    </extension>
+  </extension>
+  <identifier>
+    <use value="official" />
+    <system value="https://fhir.nhs.uk/Id/ods-organization-code" />
+    <value value="RO94" />
+  </identifier>
+  <name value="ATOS MEDICAL" />
+  <address>
+    <line value="LONGFIELDS COURT" />
+    <line value="WHARNCLIFFE BUSINESS PARK" />
+    <city value="BARNSLEY" />
+    <postalCode value="S71 3GN" />
+    <country value="ENGLAND" />
+  </address>
+</Organization>

--- a/examples/ODS-Organization-G81086-PrimaryRole-Example.xml
+++ b/examples/ODS-Organization-G81086-PrimaryRole-Example.xml
@@ -1,0 +1,132 @@
+<Organization xmlns="http://hl7.org/fhir">
+  <id value="ODS-Organization-G81086-PrimaryRole-Example" />
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-OrganisationRole">
+    <extension url="instanceID">
+      <valueInteger value="103262" />
+    </extension>
+    <extension url="roleCode">
+      <valueCodeableConcept>
+		  <coding>
+			<system value="https://ord.nhs.uk/CodeSystem/role" />
+			<code value="RO94" />
+			<display value="APPLIANCE CONTRACTOR" />
+		  </coding>
+	  </valueCodeableConcept>
+    </extension>
+    <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
+      <extension url="dateType">
+        <valueCoding>
+          <system value="https://fhir.nhs.uk/England/CodeSystem/England-PeriodType" />
+          <code value="legal" />
+          <display value="Legal" />
+        </valueCoding>
+      </extension>
+      <extension url="period">
+        <valuePeriod>
+          <start value="1974-04-01" />
+        </valuePeriod>
+      </extension>
+    </extension>
+    <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
+      <extension url="dateType">
+        <valueCoding>
+          <system value="https://fhir.nhs.uk/England/CodeSystem/England-PeriodType" />
+          <code value="operational" />
+          <display value="Operational" />
+        </valueCoding>
+      </extension>
+      <extension url="period">
+        <valuePeriod>
+          <start value="1974-04-01" />
+        </valuePeriod>
+      </extension>
+    </extension>
+    <extension url="active">
+      <valueBoolean value="true" />
+    </extension>
+  </extension>
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-DateTime">
+    <extension url="type">
+      <valueCoding>
+        <system value="https://fhir.nhs.uk/England/CodeSystem/England-ORDDateTime" />
+        <code value="last-change-date" />
+        <display value="Last Change Date" />
+      </valueCoding>
+    </extension>
+    <extension url="dateTime">
+      <valueDateTime value="2023-08-22" />
+    </extension>
+  </extension>
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
+    <extension url="dateType">
+      <valueCoding>
+        <system value="https://fhir.nhs.uk/England/CodeSystem/England-PeriodType" />
+        <code value="legal" />
+        <display value="Legal" />
+      </valueCoding>
+    </extension>
+    <extension url="period">
+      <valuePeriod>
+        <start value="1974-04-01" />
+      </valuePeriod>
+    </extension>
+  </extension>
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
+    <extension url="dateType">
+      <valueCoding>
+        <system value="https://fhir.nhs.uk/England/CodeSystem/England-PeriodType" />
+        <code value="operational" />
+        <display value="Operational" />
+      </valueCoding>
+    </extension>
+    <extension url="period">
+      <valuePeriod>
+        <start value="1974-04-01" />
+      </valuePeriod>
+    </extension>
+  </extension>
+  <identifier>
+    <use value="official" />
+    <system value="https://fhir.nhs.uk/Id/ods-organization-code" />
+    <value value="G81086" />
+  </identifier>
+    <type>
+    <coding>
+      <system value="https://ord.nhs.uk/CodeSystem/record-use-type" />
+      <code value="Full" />
+      <display value="Full" />
+    </coding>
+  </type>
+  <type>
+    <coding>
+      <system value="https://ord.nhs.uk/CodeSystem/record-class" />
+      <code value="RC1" />
+      <display value="HSCOrg" />
+    </coding>
+  </type>
+  <name value="BIRD-IN-EYE SURGERY" />
+  <telecom>
+    <system value="phone" />
+    <value value="01825 763196" />
+  </telecom>
+  <address>
+    <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AddressKey">
+      <extension url="type">
+        <valueCoding>
+          <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-AddressKeyType" />
+          <code value="UPRN" />
+          <display value="Unique Property Reference Number" />
+        </valueCoding>
+      </extension>
+      <extension url="value">
+        <valueString value="10091054340" />
+      </extension>
+    </extension>
+    <line value="UCKFIELD COMMUNITY HOSPITAL" />
+    <line value="FRAMFIELD ROAD" />
+    <city value="UCKFIELD" />
+    <district value="EAST SUSSEX" />
+    <postalCode value="TN22 5AW" />
+    <country value="ENGLAND" />
+  </address>
+</Organization>

--- a/examples/ODS-Organization-G81086-PrimaryRole-Example.xml
+++ b/examples/ODS-Organization-G81086-PrimaryRole-Example.xml
@@ -6,12 +6,12 @@
     </extension>
     <extension url="roleCode">
       <valueCodeableConcept>
-		  <coding>
-			<system value="https://ord.nhs.uk/CodeSystem/role" />
-			<code value="RO94" />
-			<display value="APPLIANCE CONTRACTOR" />
-		  </coding>
-	  </valueCodeableConcept>
+      <coding>
+      <system value="https://ord.nhs.uk/CodeSystem/role" />
+      <code value="RO94" />
+      <display value="APPLIANCE CONTRACTOR" />
+      </coding>
+    </valueCodeableConcept>
     </extension>
     <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
       <extension url="dateType">

--- a/examples/ODS-OrganizationAffiliation-G81086-Example.xml
+++ b/examples/ODS-OrganizationAffiliation-G81086-Example.xml
@@ -30,7 +30,7 @@
       </valuePeriod>
     </extension>
   </extension>
-  <active value="false"/>
+  <active value="false" />
   <organization>
     <reference value="Organization/ODS-Organization-G81086-PrimaryRole-Example" />
     <type value="Organization" />

--- a/examples/ODS-OrganizationAffiliation-G81086-Example.xml
+++ b/examples/ODS-OrganizationAffiliation-G81086-Example.xml
@@ -1,0 +1,59 @@
+<OrganizationAffiliation xmlns="http://hl7.org/fhir">
+  <id value="ODS-OrganizationAffiliation-G81086-Example" />
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
+    <extension url="dateType">
+      <valueCoding>
+        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PeriodType" />
+        <code value="legal" />
+        <display value="Legal" />
+      </valueCoding>
+    </extension>
+    <extension url="period">
+      <valuePeriod>
+        <start value="1999-04-01" />
+        <end value="2002-03-31" />
+      </valuePeriod>
+    </extension>
+  </extension>
+  <extension url="https://fhir.nhs.uk/England/StructureDefinition/Extension-England-TypedPeriod">
+    <extension url="dateType">
+      <valueCoding>
+        <system value="https://fhir.nhs.uk/England/CodeSystem/England-PeriodType" />
+        <code value="operational" />
+        <display value="Operational" />
+      </valueCoding>
+    </extension>
+    <extension url="period">
+      <valuePeriod>
+        <start value="1999-04-01" />
+        <end value="2002-03-31" />
+      </valuePeriod>
+    </extension>
+  </extension>
+  <active value="false"/>
+  <organization>
+    <reference value="Organization/ODS-Organization-G81086-PrimaryRole-Example" />
+    <type value="Organization" />
+    <identifier>
+      <use value="official" />
+      <system value="https://fhir.nhs.uk/Id/ods-organization-code" />
+      <value value="G81086" />
+    </identifier>
+  </organization>
+  <participatingOrganization>
+    <reference value="Organization/ODS-Organization-4VE03-Example" />
+    <type value="Organization" />
+    <identifier>
+      <use value="official" />
+      <system value="https://fhir.nhs.uk/Id/ods-organization-code" />
+      <value value="4VE03" />
+    </identifier>
+  </participatingOrganization>
+  <code>
+    <coding>
+      <system value="https://ord.nhs.uk/CodeSystem/relationship" />
+      <code value="RE4" />
+      <display value="IS COMMISSIONED BY" />
+    </coding>
+  </code>
+</OrganizationAffiliation>


### PR DESCRIPTION
These are for the four ODS examples.  The reason ODS-Organization-G81086-PrimaryRole-Example.xml is failing validation, is because the codings provided are not in the value set 'UK Core Organization Type', the binding strength,  is extensible so I have used a codesystem provided by the ODS team.  I tested the validation, by removing the binding used and replaced with a code from 'UK Core Organization Type, and it validated, so I know the validation error is just on this issue. It looks like the validator treats warnings as errors.

In hindsight, I should have prefixed the examples with ORD (Organisation Reference Data ) rather than ODS, let me know if you think it's worth renaming the examples.